### PR TITLE
Add Threshold Subspace Clustering (TSC) Implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [deps]
 ArnoldiMethod = "ec485272-7323-5ecc-a04f-4719b315124d"
+Clustering = "aaaa29a8-35af-508c-8bc3-b662a17a0fe5"
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -13,6 +14,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 ArnoldiMethod = "0.4.0"
+Clustering = "0.15.8"
 Compat = "3.47.0, 4.10.0"
 LinearAlgebra = "1.10"
 Logging = "1.10"

--- a/src/SubspaceClustering.jl
+++ b/src/SubspaceClustering.jl
@@ -5,18 +5,20 @@ module SubspaceClustering
 
 # Imports
 using ArnoldiMethod: partialschur
+using Clustering: kmeans
 using Compat
-using LinearAlgebra: mul!, norm, svd!
+using LinearAlgebra: mul!, norm, svd!, Diagonal, Symmetric, I, normalize
 using Logging: @info, @warn
 using ProgressLogging: @withprogress, @logprogress
 using Random: AbstractRNG, default_rng, randn!
 
 # Exports
-export KSSResult, kss
+export KSSResult, kss, TSCResult, tsc
 @compat public randsubspace
 
 # Algorithms
 include("algorithms/kss.jl")
+include("algorithms/tsc.jl")
 
 # Utility functions
 """

--- a/src/algorithms/tsc.jl
+++ b/src/algorithms/tsc.jl
@@ -1,0 +1,122 @@
+## Algorithm: TSC
+
+# Result type
+
+""""
+    TSCResult{
+        TU<:AbstractMatrix{<:AbstractFloat},
+        Tc<:AbstractVector{<:Integer},
+        T<:Real}
+
+The output of [`tsc`](@ref).
+
+# Fields
+- `U::TU`: centers matrix
+- `c::Tc`: vector of cluster assignments `c[1],...,c[N]`
+- `iterations::Int`: number of iterations performed
+- `totalcost::T`: final value of total cost function
+- `counts::Vector{Int}`: vector of cluster sizes `counts[1],...,counts[K]`
+- `converged::Bool`: final convergence status
+"""
+
+struct TSCResult{
+    TU<:AbstractMatrix{<:AbstractFloat},
+    Tc<:AbstractVector{<:Integer},
+    T<:Real,
+}
+    U::TU
+    c::Tc
+    iterations::Int
+    totalcost::T
+    counts::Vector{Int}
+    converged::Bool
+end
+
+# Main function
+
+"""
+    tsc(X::AbstractMatrix{<:Real}, k::Integer; 
+    maxiters::Integer = 100)
+
+
+Cluster the `N` data points in the `D×N` data matrix `X`
+into `K` clusters via the **T**hreshold **S**ubspace **C**lustering (TSC) algorithm.
+Output is a [`TSCResult`](@ref) containing the resulting
+cluster assignments `c[1],...,c[N]`,
+centers matrix `U` of ize `k×k`,
+and metadata about the algorithm run.
+
+Threshold subspace clustering (TSC) algorithm treats data points as nodes
+in a graph. Three important matrices that make up the TSC algorithm are
+1. **Adjacency matrix**: `S` is a `N×N` matrix where `S[i, j]` is the cosine similarity
+   between the `i`-th and `j`-th data points.
+```math
+S[i, j] = \\exp \\left[-2 \\cdot \\arccos \\left( \\frac{X[:, i]^\\top \\cdot X[:, j]}{\\|X[:, i]\\|_2 \\cdot \\|X[:, j]\\|_2} \\right) \\right]
+```
+2. **Degree matrix**: `D` is a `N×N` diagonal matrix where `D[i, i]` is the sum of the `i`-th row of `S`.
+```math
+D[i, i] = \\sum_{j=1}^N S[i, j]
+```
+3. **Laplacian matrix** `L` is a `N×N` Symmetric matrix, it captures the structure of the graph by combining
+information from the adjacency and degree matrices.
+```math
+L_sym = I - D^{-1/2} S D^{-1/2}
+```
+TSC seeks to cluster data points by performing K-means clustering on the
+normalized versions of the `k` smallest eigenvectors of the Laplacian matrix `L_sym`.
+
+# Keyword arguments
+- `maxiters::Integer = 100`: maximum number of iterations
+
+See also [`TSCResult`](@ref).
+"""
+
+
+function tsc(
+    X::AbstractMatrix{<:Real}, 
+    k::Integer;
+    maxiters::Integer = 100,
+)
+    #  Check clusters are more than 1 and not greater than the number of data points
+    2 <= k <= size(X, 2) || throw(
+        ArgumentError("Number of clusters `k` must be between 2 and the number of columns in `X`, got k = $k."),
+    )
+
+    # Check maxiters
+    maxiters >= 0 || throw(
+        ArgumentError(
+            "Maximum number of iterations must be nonnegative. Got `maxiters=$maxiters`.",
+        ),
+    )
+
+    # Affinity matrix
+    col_norms = [norm(xi) for xi in eachcol(X)]
+    Norm_vec = [xi ./ col_norms[i] for (i, xi) in pairs(eachcol(X))]
+    Norm_mat = hcat(Norm_vec...)
+    A = transpose(Norm_mat) * Norm_mat
+
+    S = exp.((-2 .* acos.(clamp.(A, -1, 1))))
+
+    # Compute node degrees and form Laplacian matrix
+    D = Diagonal(vec(sum(S, dims=2)))
+    D_sqrinv = sqrt(inv(D))
+    L_sym = Symmetric(I - (D_sqrinv * S * D_sqrinv))
+
+    # Compute eigenvectors
+    decomp, history = partialschur(L_sym; nev=k, which=:SR)
+    history.converged || @warn "Iterative algorithm for threshold subspace did not converge - results may be inaccurate."
+    V = mapslices(normalize, decomp.Q; dims=2)
+
+    # Compute cluster assignments via k-means
+    result = kmeans(permutedims(V), k; maxiter=maxiters)
+    U = result.centers
+    c = result.assignments
+    iterations = result.iterations
+    totalcost = result.totalcost
+    counts = result.counts
+    converged = result.converged
+
+    return TSCResult(U, c, iterations, totalcost, counts, converged)
+
+end
+

--- a/test/items/tsc.jl
+++ b/test/items/tsc.jl
@@ -1,0 +1,46 @@
+# tsc function
+
+@testitem "Argument validation" begin
+    using LinearAlgebra, StableRNGs
+
+    @testset "clusters > data points"  begin
+        rng = StableRNG(1)
+        X = randn(rng, 5, 30)
+
+        @test_throws ArgumentError tsc(X, 40)
+    end
+
+    @testset "invalid number of iterations" begin
+        rng = StableRNG(2)
+        X = randn(rng, 5, 20)
+
+        @test_throws ArgumentError tsc(X, 3; maxiters = -1)
+    end
+
+    @testset "invalid number of clusters" begin
+        rng = StableRNG(3)
+        X = randn(rng, 5, 40)
+
+        @test_throws ArgumentError tsc(X, 0)
+        @test_throws ArgumentError tsc(X, -1)
+        @test_throws ArgumentError tsc(X, 1)
+    end
+
+end
+
+@testitem "TSC: Basic functionality" begin
+    using LinearAlgebra, StableRNGs
+    
+    rng = StableRNG(4)
+    D, N = 5, 40
+    k = 4
+    X = randn(rng, D, N)
+    result = tsc(X, k; maxiters = 80)
+
+    @test length(result.c) == N
+    @test length(result.counts) == k
+    @test sum(result.counts) == N
+    @test result.iterations <= 80
+    @test size(result.U) == (k, k)
+
+end


### PR DESCRIPTION
### This PR introduces the implementation of Threshold Subspace Clustering (TSC) algorithm to the SubspaceClustering package

- `tsc(X, k; maxiters)` - Clusters the `D×N` matrix into `k` groups via the Threshold Subspace Clustering method.
- New `TSCResult` type for storing centers matrix `U`, cluster assignments `c`, and metadata about the algorithm run. 

#### TSC Objective: 

TSC treats data points as nodes in a graph. Internally it builds a cosine-angle-based adjacency matrix `A`, forms the symmetric normalized graph Laplacian `L_sym`, compute the `k` eigenvectors of `L_sym` associated with its smallest eigenvalues and then performs K-means clustering on the `k×N` matrix. 