### PR TITLE
Making Progress Logging Optional

### DIFF
--- a/src/algorithms/kss.jl
+++ b/src/algorithms/kss.jl
@@ -63,6 +63,7 @@ and subspace basis matrices `U[1],...,U[K]`.
     = [randsubspace(rng, size(X, 1), di) for di in d]`:
     vector of `K` initial subspace basis matrices to use
     (each `Uinit[k]` should be `D×d[k]`)
+- `progress::Bool = false`: To log progress during the algorithm run
 
 See also [`KSSResult`](@ref).
 """
@@ -74,6 +75,7 @@ function kss(
     Uinit::AbstractVector{<:AbstractMatrix{<:AbstractFloat}} = [
         randsubspace(rng, size(X, 1), di) for di in d
     ],
+    progress::Bool = false,
 )
     # Require one-based indexing
     Base.require_one_based_indexing(X, d, Uinit)
@@ -138,7 +140,7 @@ function kss(
         copyto!(cprev, c)
 
         # Log progress
-        if iterations % (maxiters ÷ 100) == 0
+        if progress && iterations % (maxiters ÷ 100) == 0
             @logprogress iterations / maxiters
         end
     end

--- a/test/items/kss.jl
+++ b/test/items/kss.jl
@@ -7,7 +7,7 @@
     D, N = 5, 20
     X = randn(rng, D, N)
     d = [2, 2]
-    result = kss(X, d)
+    result = kss(X, d; progress = true)
     U, c = result.U, result.c
 
     @test length(U) == length(d)
@@ -66,7 +66,7 @@ end
     U1 = SubspaceClustering.randsubspace(rng, D, d[1])
     U2 = SubspaceClustering.randsubspace(rng, D, d[2])
     X = hcat(U1 * randn(rng, d[1], N), U2 * randn(rng, d[2], N)) + 0.01 * randn(rng, D, 2N)
-    result = kss(X, d; Uinit = [U1, U2])
+    result = kss(X, d; Uinit = [U1, U2], progress = true)
     U, c = result.U, result.c
 
     # Checking all the points in X1 are assigned to cluster 1 and all the points in X2 are assigned to cluster 2


### PR DESCRIPTION
This PR adds new keyword argument `progress` to the `kss` function, allowing users to enable or disable progress logging during the KSS optimization run. Setting the default value as `kss(X, d; progress::Bool = false, [...])`.  