### PR TITLE
Simplify `Uinit`/`init` signatures in `kss`/`kas` functions

### DIFF
--- a/src/algorithms/kas.jl
+++ b/src/algorithms/kas.jl
@@ -134,7 +134,7 @@ function kas(
 
     # Initialize model parameters
     U = map(Uk -> float.(Uk), Uinit)
-    b = map(Uk -> float.(bk), binit)
+    b = map(bk -> float.(bk), binit)
     c = kas_assign_clusters(U, b, X)
 
     # Main loop

--- a/src/algorithms/kas.jl
+++ b/src/algorithms/kas.jl
@@ -72,7 +72,6 @@ and bias vectors `b[1],...,b[K]`.
     = [(randsubspace(rng, float(eltype(X)), size(X, 1), di), zeros(float(eltype(X)), size(X, 1))) for di in d]`:
     vector of `K` initial pair of affine space basis matrices containing `U[1],...,U[K]`
     and bias vectors containing `b[1],...,b[K]`
-    where `TUb` is a floating point type.
 - `showprogress::Bool = false`: whether to log progress during the algorithm run
 
 See also [`KASResult`](@ref).
@@ -82,14 +81,14 @@ function kas(
     d::AbstractVector{<:Integer};
     maxiters::Integer = 100,
     rng::AbstractRNG = default_rng(),
-    init::AbstractVector{<:Tuple{<:AbstractMatrix{TUb},<:AbstractVector{TUb}}} = [
+    init::AbstractVector{<:Tuple{<:AbstractMatrix{<:Number},<:AbstractVector{<:Number}}} = [
         (
             randsubspace(rng, float(eltype(X)), size(X, 1), di),
             zeros(float(eltype(X)), size(X, 1)),
         ) for di in d
     ],
     showprogress::Bool = false,
-) where {TUb<:Union{AbstractFloat,Complex{<:AbstractFloat}}}
+)
     # Unpack the initial affine space basis matrices and bias vectors
     Uinit = first.(init)
     binit = last.(init)
@@ -134,8 +133,8 @@ function kas(
     )
 
     # Initialize model parameters
-    U = deepcopy(Uinit)
-    b = deepcopy(binit)
+    U = map(Uk -> float.(Uk), Uinit)
+    b = map(Uk -> float.(bk), binit)
     c = kas_assign_clusters(U, b, X)
 
     # Main loop

--- a/src/algorithms/kss.jl
+++ b/src/algorithms/kss.jl
@@ -74,9 +74,9 @@ function kss(
     d::AbstractVector{<:Integer};
     maxiters::Integer = 100,
     rng::AbstractRNG = default_rng(),
-    Uinit::AbstractVector{
-        <:AbstractMatrix{<:Number},
-    } = [randsubspace(rng, float(eltype(X)), size(X, 1), di) for di in d],
+    Uinit::AbstractVector{<:AbstractMatrix{<:Number}} = [
+        randsubspace(rng, float(eltype(X)), size(X, 1), di) for di in d
+    ],
     showprogress::Bool = false,
 )
     # Require one-based indexing

--- a/src/algorithms/kss.jl
+++ b/src/algorithms/kss.jl
@@ -63,8 +63,8 @@ and subspace basis matrices `U[1],...,U[K]`.
 - `Uinit::AbstractVector{<:AbstractMatrix{T}}
     = [randsubspace(rng, float(eltype(X)), size(X, 1), di) for di in d]`:
     vector of `K` initial subspace basis matrices to use
-    (each `Uinit[k]` should be `D×d[k]` and have eltype `T`
-    where `T` is a floating point type)
+    (each `Uinit[k]` should be `D×d[k]`; numeric inputs are converted to
+    floating point internally)
 - `showprogress::Bool = false`: whether to log progress during the algorithm run
 
 See also [`KSSResult`](@ref).
@@ -75,7 +75,7 @@ function kss(
     maxiters::Integer = 100,
     rng::AbstractRNG = default_rng(),
     Uinit::AbstractVector{
-        <:AbstractMatrix{<:Union{AbstractFloat,Complex{<:AbstractFloat}}},
+        <:AbstractMatrix{<:Number},
     } = [randsubspace(rng, float(eltype(X)), size(X, 1), di) for di in d],
     showprogress::Bool = false,
 )
@@ -111,7 +111,7 @@ function kss(
     )
 
     # Initialize model parameters
-    U = deepcopy(Uinit)
+    U = map(Uk -> float.(Uk), Uinit)
     c = kss_assign_clusters(U, X)
 
     # Main loop

--- a/src/algorithms/kss.jl
+++ b/src/algorithms/kss.jl
@@ -60,7 +60,7 @@ and subspace basis matrices `U[1],...,U[K]`.
 - `maxiters::Integer = 100`: maximum number of iterations
 - `rng::AbstractRNG = default_rng()`: random number generator
     (used when reinitializing the subspace for an empty cluster)
-- `Uinit::AbstractVector{<:AbstractMatrix{T}}
+- `Uinit::AbstractVector{<:AbstractMatrix{<:Number}}
     = [randsubspace(rng, float(eltype(X)), size(X, 1), di) for di in d]`:
     vector of `K` initial subspace basis matrices to use
     (each `Uinit[k]` should be `D×d[k]`; numeric inputs are converted to

--- a/test/items/algorithms/kas.jl
+++ b/test/items/algorithms/kas.jl
@@ -173,7 +173,7 @@ end
 
     @test all(eltype(Uk) <: Integer && eltype(bk) <: Integer for (Uk, bk) in init)
 
-    result = kas(X, d, init = init)
+    result = kas(X, d; init = init)
 
     @test eltype(result.U[1]) <: AbstractFloat
     @test eltype(result.b[1]) <: AbstractFloat

--- a/test/items/algorithms/kas.jl
+++ b/test/items/algorithms/kas.jl
@@ -171,10 +171,7 @@ end
 
     init = [(U1, b1), (U2, b2)]
 
-    @test eltype(U1) <: Integer
-    @test eltype(b1) <: Integer
-    @test eltype(U2) <: Integer
-    @test eltype(b2) <: Integer
+    @test all(eltype(Uk) <: Integer && eltype(bk) <: Integer for (Uk, bk) in init)
 
     result = kas(X, d, init = init)
 

--- a/test/items/algorithms/kas.jl
+++ b/test/items/algorithms/kas.jl
@@ -155,3 +155,31 @@ end
         @test isempty(filter(l -> l.level == ProgressLogging.ProgressLevel, logger.logs))
     end
 end
+
+@testitem "Integer init is converted to floating point" begin
+    using LinearAlgebra, StableRNGs
+
+    rng = StableRNG(7)
+    D, N = 5, 20
+    X = randn(rng, D, N)
+    d = [2, 3]
+
+    U1 = rand(rng, 1:5, D, d[1])
+    b1 = rand(rng, 1:5, D)
+    U2 = rand(rng, 1:5, D, d[2])
+    b2 = rand(rng, 1:5, D)
+
+    init = [(U1, b1), (U2, b2)]
+
+    @test eltype(U1) <: Integer
+    @test eltype(b1) <: Integer
+    @test eltype(U2) <: Integer
+    @test eltype(b2) <: Integer
+
+    result = kas(X, d, init = init)
+
+    @test eltype(result.U[1]) <: AbstractFloat
+    @test eltype(result.b[1]) <: AbstractFloat
+    @test eltype(result.U[2]) <: AbstractFloat
+    @test eltype(result.b[2]) <: AbstractFloat
+end

--- a/test/items/algorithms/kas.jl
+++ b/test/items/algorithms/kas.jl
@@ -97,7 +97,7 @@ end
 
         # Checking all the points in X1 are assigned to cluster 1 and all the points in X2 are assigned to cluster 2
         @test all(c[1:N] .== 1)
-        @test all(c[N+1:end] .== 2)
+        @test all(c[(N+1):end] .== 2)
 
         # Confirming the clusters are not empty
         for k in 1:length(d)

--- a/test/items/algorithms/kss.jl
+++ b/test/items/algorithms/kss.jl
@@ -146,7 +146,7 @@ end
     rng = StableRNG(7)
     D, N = 5, 20
     X = randn(rng, D, N)
-    d= [2, 3]
+    d = [2, 3]
 
     Uinit = [rand(rng, 1:5, D, d[1]), rand(rng, 1:5, D, d[2])]
 

--- a/test/items/algorithms/kss.jl
+++ b/test/items/algorithms/kss.jl
@@ -139,3 +139,22 @@ end
         @test isempty(filter(l -> l.level == ProgressLogging.ProgressLevel, logger.logs))
     end
 end
+
+@testitem "Integer Uinit is converted to floating point" begin
+    using LinearAlgebra, StableRNGs
+
+    rng = StableRNG(7)
+    D, N = 5, 20
+    X = randn(rng, D, N)
+    d=[2, 3]
+
+    Uinit = [rand(rng, 1:5, D, d[1]), rand(rng, 1:5, D, d[2])]
+
+    @test eltype(Uinit[1]) <: Integer
+    @test eltype(Uinit[2]) <: Integer
+
+    result = kss(X, d; Uinit = Uinit)
+
+    @test eltype(result.U[1]) <: AbstractFloat
+    @test eltype(result.U[2]) <: AbstractFloat
+end

--- a/test/items/algorithms/kss.jl
+++ b/test/items/algorithms/kss.jl
@@ -146,7 +146,7 @@ end
     rng = StableRNG(7)
     D, N = 5, 20
     X = randn(rng, D, N)
-    d=[2, 3]
+    d= [2, 3]
 
     Uinit = [rand(rng, 1:5, D, d[1]), rand(rng, 1:5, D, d[2])]
 

--- a/test/items/utils/progresslogging.jl
+++ b/test/items/utils/progresslogging.jl
@@ -11,7 +11,7 @@
         end
     end
     logged_progress = [log.kwargs[:progress] for log in logger.logs]
-    @test logged_progress == [nothing; 1/3:1/3:1; "done"]
+    @test logged_progress == [nothing; (1/3):(1/3):1; "done"]
 end
 
 @testitem "@withprogressif false / @logprogressif false" begin
@@ -72,7 +72,7 @@ end
         end
     end
     logged_progress = [log.kwargs[:progress] for log in logger.logs]
-    @test logged_progress == repeat([nothing; 1/2:1/2:1; "done"], 2)
+    @test logged_progress == repeat([nothing; (1/2):(1/2):1; "done"], 2)
     logged_messages = [string(log.message) for log in logger.logs]
     @test all(==("inner"), logged_messages)
 end


### PR DESCRIPTION
### This PR simplifies the initialization signatures in `kss` and `kas` by relaxing type constraints on `Uinit` and `init` keyword arguments

- Allows generic numeric inputs instead of requiring floating point types.
- Added test cases to verify `kss` and `kas` accept integer valued initializations and the inputs are converted to floating point internally. 
- More flexible API.  