### PR TITLE
Add custom show methods for clustering result types

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -69,7 +69,7 @@ end
 
 # Plot data points
 points = map(1:K) do j
-    scatter!(ax, [Point2f(x[i]) for i in 1:N if result.c[i] == j];
+    scatter!(ax, [Point2f(x[i]) for i in 1:N if result.assignments[i] == j];
         markersize = 6, color = Cycled(j+1))
 end
 

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -156,13 +156,13 @@ We can extract each of these as follows:
 
 ```@repl
 result.U
-result.c
+result.assignments
 ```
 
 To see how well `kss` clustered the data points,
 we plot these estimated subspaces `results.U`
 together with the data points
-colored by the estimated cluster assignments `results.c`
+colored by the estimated cluster assignments `results.assignments`
 (the uncolored data points seen by `kss` are shown on the left):
 
 ```@setup
@@ -204,7 +204,7 @@ end
 
 # Plot data points
 points = map(1:K) do j
-    scatter!(ax, [Point2f(x[i]) for i in 1:N if result.c[i] == j];
+    scatter!(ax, [Point2f(x[i]) for i in 1:N if result.assignments[i] == j];
         markersize = 6, color = Cycled(j+1))
 end
 

--- a/src/SubspaceClustering.jl
+++ b/src/SubspaceClustering.jl
@@ -13,6 +13,7 @@ using ProgressLogging: @logprogress, @withprogress
 using Random: AbstractRNG, default_rng, randn!
 using SparseArrays: sparse
 using Statistics: mean
+import Base: show
 
 # Exports
 export KASResult, kas, KSSResult, kss, TSCResult, tsc

--- a/src/algorithms/kas.jl
+++ b/src/algorithms/kas.jl
@@ -37,6 +37,27 @@ struct KASResult{
     converged::Bool
 end
 
+function show(io::IO, ::MIME"text/plain", result::KASResult)
+    println(io, " KASResult ($(length(result.counts)) clusters, $(length(result.c)) cluster assignments)")
+    println(io)
+
+    assignments_preview = 
+        length(result.c) > 10 ?
+        string("[", join(result.c[1:10], ","), ", ...]") :
+        string(result.c)
+    
+    println(io, " c (assignments):  ", assignments_preview)
+    println(io)
+    println(io, " Additional Fields: ")
+    println(io)
+    println(io, " counts        :   ", result.counts)
+    println(io, " iterations    :   ", result.iterations)
+    println(io, " converged     :   ", result.converged)
+    println(io, " U             ::  ", typeof(result.U))
+    println(io, " b             ::  ", typeof(result.b))
+    println(io, " totalcost     ::  ", typeof(result.totalcost))
+end
+
 # Main function
 
 """

--- a/src/algorithms/kas.jl
+++ b/src/algorithms/kas.jl
@@ -15,7 +15,7 @@ The output of [`kas`](@ref).
 # Fields
 - `U::TU`: vector of affine space basis matrices `U[1],...,U[K]`
 - `b::Tb`: vector of bias vectors `b[1],...,b[K]`
-- `c::Tc`: vector of cluster assignments `c[1],...,c[N]`
+- `assignments::Tc`: vector of cluster assignments `assignments[1],...,assignments[N]`
 - `iterations::Int`: number of iterations performed
 - `totalcost::T`: final value of total cost function
 - `counts::Vector{Int}`: vector of cluster sizes `counts[1],...,counts[K]`
@@ -30,7 +30,7 @@ struct KASResult{
 }
     U::TU
     b::Tb
-    c::Tc
+    assignments::Tc
     iterations::Int
     totalcost::T
     counts::Vector{Int}
@@ -38,24 +38,24 @@ struct KASResult{
 end
 
 function show(io::IO, ::MIME"text/plain", result::KASResult)
-    println(io, " KASResult ($(length(result.counts)) clusters, $(length(result.c)) cluster assignments)")
+    println(io, " KASResult ($(length(result.counts)) clusters, $(length(result.assignments)) cluster assignments)")
     println(io)
 
     assignments_preview = 
-        length(result.c) > 10 ?
-        string("[", join(result.c[1:10], ","), ", ...]") :
-        string(result.c)
+        length(result.assignments) > 10 ?
+        string("[", join(result.assignments[1:10], ","), ", ...]") :
+        string(result.assignments)
     
-    println(io, " c (assignments):  ", assignments_preview)
+    println(io, " assignments       :   ", assignments_preview)
     println(io)
     println(io, " Additional Fields: ")
     println(io)
-    println(io, " counts        :   ", result.counts)
-    println(io, " iterations    :   ", result.iterations)
-    println(io, " converged     :   ", result.converged)
-    println(io, " U             ::  ", typeof(result.U))
-    println(io, " b             ::  ", typeof(result.b))
-    println(io, " totalcost     ::  ", typeof(result.totalcost))
+    println(io, " counts            :   ", result.counts)
+    println(io, " iterations        :   ", result.iterations)
+    println(io, " converged         :   ", result.converged)
+    println(io, " U                 ::  ", typeof(result.U))
+    println(io, " b                 ::  ", typeof(result.b))
+    println(io, " totalcost         ::  ", typeof(result.totalcost))
 end
 
 # Main function
@@ -71,7 +71,7 @@ Cluster the `N` data points in the `D×N` data matrix `X`
 into `K` clusters via the **K**-**a**ffine-**s**paces (KAS) algorithm
 with corresponding affine space dimensions `d[1],...,d[K]`.
 Output is a [`KASResult`](@ref) containing the resulting
-cluster assignments `c[1],...,c[N]`,
+cluster assignments `assignments[1],...,assignments[N]`,
 affine space basis matrices `U[1],...,U[K]`,
 bias vectors `b[1],...,b[K]`,
 and metadata about the algorithm run.
@@ -79,9 +79,9 @@ and metadata about the algorithm run.
 KAS seeks to cluster data points by their affine space
 by minimizing the following total cost
 ```math
-\\sum_{i=1}^N \\| X[:, i] - (U[c[i]] U[c[i]]' (X[:, i] - b[c[i]]) + b[c[i]]) \\|_2^2
+\\sum_{i=1}^N \\| X[:, i] - (U[assignments[i]] U[assignments[i]]' (X[:, i] - b[assignments[i]]) + b[assignments[i]]) \\|_2^2
 ```
-with respect to the cluster assignments `c[1],...,c[N]`,
+with respect to the cluster assignments `assignments[1],...,assignments[N]`,
 affine space basis matrices `U[1],...,U[K]`,
 and bias vectors `b[1],...,b[K]`.
 
@@ -157,10 +157,10 @@ function kas(
     # Initialize model parameters
     U = deepcopy(Uinit)
     b = deepcopy(binit)
-    c = kas_assign_clusters(U, b, X)
+    assignments = kas_assign_clusters(U, b, X)
 
     # Main loop
-    cprev = copy(c)
+    cprev = copy(assignments)
     iterations, converged = 0, false
     log_every = max(1, maxiters ÷ 100)
     @withprogressif showprogress while iterations < maxiters && !converged
@@ -168,7 +168,7 @@ function kas(
 
         # Update affine space basis matrices and bias vectors
         for k in 1:K
-            inds = findall(==(k), c)
+            inds = findall(==(k), assignments)
             if !isempty(inds)
                 U[k], b[k] = kas_estimate_affinespace(view(X, :, inds), d[k])
             else
@@ -179,14 +179,14 @@ function kas(
         end
 
         # Update cluster assignments
-        kas_assign_clusters!(c, U, b, X)
+        kas_assign_clusters!(assignments, U, b, X)
 
         # Check for convergence
-        if cprev == c
+        if cprev == assignments
             @info "Converged after $iterations $(iterations == 1 ? "iteration" : "iterations")."
             converged = true
         end
-        copyto!(cprev, c)
+        copyto!(cprev, assignments)
 
         # Log progress
         if iterations % log_every == 0
@@ -195,13 +195,13 @@ function kas(
     end
 
     # Compute final counts and costs
-    counts = [count(==(k), c) for k in 1:K]
+    counts = [count(==(k), assignments) for k in 1:K]
     costs = [
-        sum(abs2, (xi - b[c[i]])) - sum(abs2, U[c[i]]' * (xi - b[c[i]])) for
+        sum(abs2, (xi - b[assignments[i]])) - sum(abs2, U[assignments[i]]' * (xi - b[assignments[i]])) for
         (i, xi) in pairs(eachcol(X))
     ]
 
-    return KASResult(U, b, c, iterations, sum(costs), counts, converged)
+    return KASResult(U, b, assignments, iterations, sum(costs), counts, converged)
 end
 
 # Subroutines
@@ -218,21 +218,21 @@ kas_assign_clusters(U, b, X) =
     kas_assign_clusters!(similar(Vector{Int}, (axes(X, 2),)), U, b, X)
 
 """
-    kas_assign_clusters!(c, U, b, X)
+    kas_assign_clusters!(assignments, U, b, X)
 
 Assign the `N` data points in `X` to the `K` affine spaces in `(U,b)`,
-update the vector of assignments `c`,
-and return this vector of assignments.
+update the vector `assignments`,
+and return the final vector of assignments.
 
 See also [`kas_assign_clusters`](@ref), [`kas`](@ref).
 """
-function kas_assign_clusters!(c, U, b, X)
+function kas_assign_clusters!(assignments, U, b, X)
     for (i, xi) in pairs(eachcol(X))
-        c[i] = argmin(
+        assignments[i] = argmin(
             sum(abs2, (xi - b[k])) - sum(abs2, U[k]' * (xi - b[k])) for k in eachindex(U)
         )
     end
-    return c
+    return assignments
 end
 
 """

--- a/src/algorithms/kas.jl
+++ b/src/algorithms/kas.jl
@@ -58,7 +58,7 @@ function show(io::IO, ::MIME"text/plain", result::KASResult)
     println(io, " converged         :   ", result.converged)
     println(io, " U                 ::  ", typeof(result.U))
     println(io, " b                 ::  ", typeof(result.b))
-    println(io, " totalcost         ::  ", typeof(result.totalcost))
+    return println(io, " totalcost         ::  ", typeof(result.totalcost))
 end
 
 # Main function

--- a/src/algorithms/kas.jl
+++ b/src/algorithms/kas.jl
@@ -38,14 +38,17 @@ struct KASResult{
 end
 
 function show(io::IO, ::MIME"text/plain", result::KASResult)
-    println(io, " KASResult ($(length(result.counts)) clusters, $(length(result.assignments)) cluster assignments)")
+    println(
+        io,
+        " KASResult ($(length(result.counts)) clusters, $(length(result.assignments)) cluster assignments)",
+    )
     println(io)
 
-    assignments_preview = 
+    assignments_preview =
         length(result.assignments) > 10 ?
         string("[", join(result.assignments[1:10], ","), ", ...]") :
         string(result.assignments)
-    
+
     println(io, " assignments       :   ", assignments_preview)
     println(io)
     println(io, " Additional Fields: ")
@@ -197,7 +200,8 @@ function kas(
     # Compute final counts and costs
     counts = [count(==(k), assignments) for k in 1:K]
     costs = [
-        sum(abs2, (xi - b[assignments[i]])) - sum(abs2, U[assignments[i]]' * (xi - b[assignments[i]])) for
+        sum(abs2, (xi - b[assignments[i]])) -
+        sum(abs2, U[assignments[i]]' * (xi - b[assignments[i]])) for
         (i, xi) in pairs(eachcol(X))
     ]
 

--- a/src/algorithms/kss.jl
+++ b/src/algorithms/kss.jl
@@ -51,7 +51,7 @@ function show(io::IO, ::MIME"text/plain", result::KSSResult)
     println(io, " iterations        :   ", result.iterations)
     println(io, " converged         :   ", result.converged)
     println(io, " U                 ::  ", typeof(result.U))
-    println(io, " totalcost         ::  ", typeof(result.totalcost))
+    return println(io, " totalcost         ::  ", typeof(result.totalcost))
 end
 
 # Main function

--- a/src/algorithms/kss.jl
+++ b/src/algorithms/kss.jl
@@ -45,7 +45,7 @@ function show(io::IO, ::MIME"text/plain", result::KSSResult)
 
     println(io, " assignments       :   ", assignments_preview)
     println(io)
-    println(io, " Additional Fields:")
+    println(io, " Additional Fields: ")
     println(io)
     println(io, " counts            :   ", result.counts)
     println(io, " iterations        :   ", result.iterations)

--- a/src/algorithms/kss.jl
+++ b/src/algorithms/kss.jl
@@ -32,14 +32,17 @@ struct KSSResult{
 end
 
 function show(io::IO, ::MIME"text/plain", result::KSSResult)
-    println(io, " KSSResult ($(length(result.counts)) clusters, $(length(result.assignments)) cluster assignments)")
+    println(
+        io,
+        " KSSResult ($(length(result.counts)) clusters, $(length(result.assignments)) cluster assignments)",
+    )
     println(io)
 
-    assignments_preview = 
+    assignments_preview =
         length(result.assignments) > 10 ?
         string("[", join(result.assignments[1:10], ","), ", ...]") :
         string(result.assignments)
-    
+
     println(io, " assignments       :   ", assignments_preview)
     println(io)
     println(io, " Additional Fields:")
@@ -170,7 +173,9 @@ function kss(
 
     # Compute final counts and costs
     counts = [count(==(k), assignments) for k in 1:K]
-    costs = [sum(abs2, xi) - sum(abs2, U[assignments[i]]' * xi) for (i, xi) in pairs(eachcol(X))]
+    costs = [
+        sum(abs2, xi) - sum(abs2, U[assignments[i]]' * xi) for (i, xi) in pairs(eachcol(X))
+    ]
 
     return KSSResult(U, assignments, iterations, sum(costs), counts, converged)
 end

--- a/src/algorithms/kss.jl
+++ b/src/algorithms/kss.jl
@@ -32,7 +32,7 @@ struct KSSResult{
 end
 
 function show(io::IO, ::MIME"text/plain", result::KSSResult)
-    println(io, "KSSResult ($(length(result.counts)) clusters, $(length(result.c)) assignments)")
+    println(io, " KSSResult ($(length(result.counts)) clusters, $(length(result.c)) cluster assignments)")
     println(io)
 
     assignments_preview = 
@@ -40,15 +40,15 @@ function show(io::IO, ::MIME"text/plain", result::KSSResult)
         string("[", join(result.c[1:10], ","), ", ...]") :
         string(result.c)
     
-    println(io, " assignments: ", assignments_preview)
-    println(io, " counts: ", result.counts)
-    println(io, " iterations: ", result.iterations)
-    println(io, " converged: ", result.converged)
-
+    println(io, " c (assignments):  ", assignments_preview)
     println(io)
     println(io, " Additional Fields:")
-    println(io, " U         ::", typeof(result.U))
-    println(io, " totalcost ::", typeof(result.totalcost))
+    println(io)
+    println(io, " counts        :   ", result.counts)
+    println(io, " iterations    :   ", result.iterations)
+    println(io, " converged     :   ", result.converged)
+    println(io, " U             ::  ", typeof(result.U))
+    println(io, " totalcost     ::  ", typeof(result.totalcost))
 end
 
 # Main function

--- a/src/algorithms/kss.jl
+++ b/src/algorithms/kss.jl
@@ -31,6 +31,26 @@ struct KSSResult{
     converged::Bool
 end
 
+function show(io::IO, ::MIME"text/plain", result::KSSResult)
+    println(io, "KSSResult ($(length(result.counts)) clusters, $(length(result.c)) assignments)")
+    println(io)
+
+    assignments_preview = 
+        length(result.c) > 10 ?
+        string("[", join(result.c[1:10], ","), ", ...]") :
+        string(result.c)
+    
+    println(io, " assignments: ", assignments_preview)
+    println(io, " counts: ", result.counts)
+    println(io, " iterations: ", result.iterations)
+    println(io, " converged: ", result.converged)
+
+    println(io)
+    println(io, " Additional Fields:")
+    println(io, " U         ::", typeof(result.U))
+    println(io, " totalcost ::", typeof(result.totalcost))
+end
+
 # Main function
 
 """

--- a/src/algorithms/kss.jl
+++ b/src/algorithms/kss.jl
@@ -12,7 +12,7 @@ The output of [`kss`](@ref).
 
 # Fields
 - `U::TU`: vector of subspace basis matrices `U[1],...,U[K]`
-- `c::Tc`: vector of cluster assignments `c[1],...,c[N]`
+- `assignments::Tc`: vector of cluster assignments `assignments[1],...,assignments[N]`
 - `iterations::Int`: number of iterations performed
 - `totalcost::T`: final value of total cost function
 - `counts::Vector{Int}`: vector of cluster sizes `counts[1],...,counts[K]`
@@ -24,7 +24,7 @@ struct KSSResult{
     T<:Real,
 }
     U::TU
-    c::Tc
+    assignments::Tc
     iterations::Int
     totalcost::T
     counts::Vector{Int}
@@ -32,23 +32,23 @@ struct KSSResult{
 end
 
 function show(io::IO, ::MIME"text/plain", result::KSSResult)
-    println(io, " KSSResult ($(length(result.counts)) clusters, $(length(result.c)) cluster assignments)")
+    println(io, " KSSResult ($(length(result.counts)) clusters, $(length(result.assignments)) cluster assignments)")
     println(io)
 
     assignments_preview = 
-        length(result.c) > 10 ?
-        string("[", join(result.c[1:10], ","), ", ...]") :
-        string(result.c)
+        length(result.assignments) > 10 ?
+        string("[", join(result.assignments[1:10], ","), ", ...]") :
+        string(result.assignments)
     
-    println(io, " c (assignments):  ", assignments_preview)
+    println(io, " assignments       :   ", assignments_preview)
     println(io)
     println(io, " Additional Fields:")
     println(io)
-    println(io, " counts        :   ", result.counts)
-    println(io, " iterations    :   ", result.iterations)
-    println(io, " converged     :   ", result.converged)
-    println(io, " U             ::  ", typeof(result.U))
-    println(io, " totalcost     ::  ", typeof(result.totalcost))
+    println(io, " counts            :   ", result.counts)
+    println(io, " iterations        :   ", result.iterations)
+    println(io, " converged         :   ", result.converged)
+    println(io, " U                 ::  ", typeof(result.U))
+    println(io, " totalcost         ::  ", typeof(result.totalcost))
 end
 
 # Main function
@@ -64,16 +64,16 @@ Cluster the `N` data points in the `D×N` data matrix `X`
 into `K` clusters via the **K**-**s**ub**s**paces (KSS) algorithm
 with corresponding subspace dimensions `d[1],...,d[K]`.
 Output is a [`KSSResult`](@ref) containing the resulting
-cluster assignments `c[1],...,c[N]`,
+cluster assignments `assignments[1],...,assignments[N]`,
 subspace basis matrices `U[1],...,U[K]`,
 and metadata about the algorithm run.
 
 KSS seeks to cluster data points by their subspace
 by minimizing the following total cost
 ```math
-\\sum_{i=1}^N \\| X[:, i] - U[c[i]] U[c[i]]' X[:, i] \\|_2^2
+\\sum_{i=1}^N \\| X[:, i] - U[assignments[i]] U[assignments[i]]' X[:, i] \\|_2^2
 ```
-with respect to the cluster assignments `c[1],...,c[N]`
+with respect to the cluster assignments `assignments[1],...,assignments[N]`
 and subspace basis matrices `U[1],...,U[K]`.
 
 # Keyword arguments
@@ -132,10 +132,10 @@ function kss(
 
     # Initialize model parameters
     U = deepcopy(Uinit)
-    c = kss_assign_clusters(U, X)
+    assignments = kss_assign_clusters(U, X)
 
     # Main loop
-    cprev = copy(c)
+    cprev = copy(assignments)
     iterations, converged = 0, false
     log_every = max(1, maxiters ÷ 100)
     @withprogressif showprogress while iterations < maxiters && !converged
@@ -143,7 +143,7 @@ function kss(
 
         # Update subspaces
         for k in 1:K
-            inds = findall(==(k), c)
+            inds = findall(==(k), assignments)
             if !isempty(inds)
                 U[k] = kss_estimate_subspace(view(X, :, inds), d[k])
             else
@@ -153,14 +153,14 @@ function kss(
         end
 
         # Update cluster assignments
-        kss_assign_clusters!(c, U, X)
+        kss_assign_clusters!(assignments, U, X)
 
         # Check for convergence
-        if cprev == c
+        if cprev == assignments
             @info "Converged after $iterations $(iterations == 1 ? "iteration" : "iterations")."
             converged = true
         end
-        copyto!(cprev, c)
+        copyto!(cprev, assignments)
 
         # Log progress
         if iterations % log_every == 0
@@ -169,10 +169,10 @@ function kss(
     end
 
     # Compute final counts and costs
-    counts = [count(==(k), c) for k in 1:K]
-    costs = [sum(abs2, xi) - sum(abs2, U[c[i]]' * xi) for (i, xi) in pairs(eachcol(X))]
+    counts = [count(==(k), assignments) for k in 1:K]
+    costs = [sum(abs2, xi) - sum(abs2, U[assignments[i]]' * xi) for (i, xi) in pairs(eachcol(X))]
 
-    return KSSResult(U, c, iterations, sum(costs), counts, converged)
+    return KSSResult(U, assignments, iterations, sum(costs), counts, converged)
 end
 
 # Subroutines
@@ -188,19 +188,19 @@ See also [`kss_assign_clusters!`](@ref), [`kss`](@ref).
 kss_assign_clusters(U, X) = kss_assign_clusters!(similar(Vector{Int}, (axes(X, 2),)), U, X)
 
 """
-    kss_assign_clusters!(c, U, X)
+    kss_assign_clusters!(assignments, U, X)
 
 Assign the `N` data points in `X` to the `K` subspaces in `U`,
-update the vector of assignments `c`,
-and return this vector of assignments.
+update the vector `assignments`,
+and returns the final vector of cluster assignments.
 
 See also [`kss_assign_clusters`](@ref), [`kss`](@ref).
 """
-function kss_assign_clusters!(c, U, X)
+function kss_assign_clusters!(assignments, U, X)
     for (i, xi) in pairs(eachcol(X))
-        c[i] = argmax(sum(abs2, U[k]' * xi) for k in eachindex(U))
+        assignments[i] = argmax(sum(abs2, U[k]' * xi) for k in eachindex(U))
     end
-    return c
+    return assignments
 end
 
 """

--- a/src/algorithms/tsc.jl
+++ b/src/algorithms/tsc.jl
@@ -32,7 +32,7 @@ end
 function show(io::IO, ::MIME"text/plain", result::TSCResult)
     println(
         io,
-        " TSC Result ($(size(result.embedding, 1)) clusters, $(length(result.assignments)) cluster assignments)",
+        " TSCResult ($(size(result.embedding, 1)) clusters, $(length(result.assignments)) cluster assignments)",
     )
     println(io)
 
@@ -41,19 +41,19 @@ function show(io::IO, ::MIME"text/plain", result::TSCResult)
         string("[", join(result.assignments[1:10], ","), ", ...]") :
         string(result.assignments)
 
-    println(io, " assignments   :   ", assignments_preview)
+    println(io, " assignments       :   ", assignments_preview)
     println(io)
     println(io, " Additional Fields: ")
     println(io)
     println(
         io,
-        " affinity      :   $(size(result.affinity, 1))x$(size(result.affinity, 2)) matrix",
+        " affinity          :   $(size(result.affinity, 1))x$(size(result.affinity, 2)) matrix",
     )
     println(
         io,
-        " embedding     :   $(size(result.embedding, 1))x$(size(result.embedding, 2)) matrix",
+        " embedding         :   $(size(result.embedding, 1))x$(size(result.embedding, 2)) matrix",
     )
-    return println(io, " kmeans_runs   :   ", length(result.kmeans_runs))
+    return println(io, " kmeans_runs       :   ", length(result.kmeans_runs))
 end
 
 # Main function

--- a/src/algorithms/tsc.jl
+++ b/src/algorithms/tsc.jl
@@ -29,6 +29,33 @@ struct TSCResult{
     assignments::Tc
 end
 
+function show(io::IO, ::MIME"text/plain", result::TSCResult)
+    println(
+        io,
+        " TSC Result ($(size(result.embedding, 1)) clusters, $(length(result.assignments)) cluster assignments)",
+    )
+    println(io)
+
+    assignments_preview =
+        length(result.assignments) > 10 ?
+        string("[", join(result.assignments[1:10], ","), ", ...]") :
+        string(result.assignments)
+
+    println(io, " assignments   :   ", assignments_preview)
+    println(io)
+    println(io, " Additional Fields: ")
+    println(io)
+    println(
+        io,
+        " affinity      :   $(size(result.affinity, 1))x$(size(result.affinity, 2)) matrix",
+    )
+    println(
+        io,
+        " embedding     :   $(size(result.embedding, 1))x$(size(result.embedding, 2)) matrix",
+    )
+    println(io, " kmeans_runs   :   ", length(result.kmeans_runs))
+end
+
 # Main function
 
 """

--- a/src/algorithms/tsc.jl
+++ b/src/algorithms/tsc.jl
@@ -53,7 +53,7 @@ function show(io::IO, ::MIME"text/plain", result::TSCResult)
         io,
         " embedding     :   $(size(result.embedding, 1))x$(size(result.embedding, 2)) matrix",
     )
-    println(io, " kmeans_runs   :   ", length(result.kmeans_runs))
+    return println(io, " kmeans_runs   :   ", length(result.kmeans_runs))
 end
 
 # Main function

--- a/test/items/algorithms/kas.jl
+++ b/test/items/algorithms/kas.jl
@@ -9,7 +9,7 @@
         X = randn(rng, T, D, N)
         d = [2, 2]
         result = kas(X, d)
-        U, b, c = result.U, result.b, result.c
+        U, b, c = result.U, result.b, result.assignments
 
         @test length(U) == length(d)
         @test length(c) == N
@@ -38,7 +38,7 @@ end
         X = randn(rng, T, D, N)
         d = [2, 3, 4]
         result = kas(X, d)
-        U, b, c = result.U, result.b, result.c
+        U, b, c = result.U, result.b, result.assignments
 
         @test length(U) == length(d)
         @test length(c) == N
@@ -72,7 +72,7 @@ end
         U2 = SubspaceClustering.randsubspace(rng, T, D, d[2])
         b2 = zeros(T, D)
         result = kas(X, d; init = [(U1, b1), (U2, b2)])
-        U, b, c = result.U, result.b, result.c
+        U, b, c = result.U, result.b, result.assignments
 
         @test isempty(findall(==(2), c))
     end
@@ -93,11 +93,11 @@ end
             hcat(U1 * randn(rng, d[1], N) .+ b1, U2 * randn(rng, d[2], N) .+ b2) .+
             0.01 * randn(rng, D, 2N)
         result = kas(X, d; init = [(U1, b1), (U2, b2)])
-        U, b, c = result.U, result.b, result.c
+        U, b, c = result.U, result.b, result.assignments
 
         # Checking all the points in X1 are assigned to cluster 1 and all the points in X2 are assigned to cluster 2
         @test all(c[1:N] .== 1)
-        @test all(c[N+1:end] .== 2)
+        @test all(c[(N+1):end] .== 2)
 
         # Confirming the clusters are not empty
         for k in 1:length(d)

--- a/test/items/algorithms/kas.jl
+++ b/test/items/algorithms/kas.jl
@@ -155,3 +155,31 @@ end
         @test isempty(filter(l -> l.level == ProgressLogging.ProgressLevel, logger.logs))
     end
 end
+
+@testitem "KASResult show method" begin
+    using StableRNGs
+
+    X = randn(StableRNG(5), 5, 40)
+    result = kas(X, [1, 1]; rng = StableRNG(5))
+    
+    output = sprint((io, x) -> show(io, "text/plain", x), result)
+
+    assignments_preview = 
+        length(result.assignments) > 10 ?
+        string("[", join(result.assignments[1:10], ","), ", ...]") :
+        string(result.assignments)
+    
+    expected_string = string(
+        
+        " KASResult ($(length(result.counts)) clusters, $(length(result.assignments)) cluster assignments)\n\n",
+        " assignments       :   $(assignments_preview)\n\n",
+        " Additional Fields: \n\n",
+        " counts            :   $(result.counts)\n",
+        " iterations        :   $(result.iterations)\n",
+        " converged         :   $(result.converged)\n",
+        " U                 ::  $(typeof(result.U))\n",
+        " b                 ::  $(typeof(result.b))\n",
+        " totalcost         ::  $(typeof(result.totalcost))\n",
+    )
+    @test output == expected_string
+end

--- a/test/items/algorithms/kas.jl
+++ b/test/items/algorithms/kas.jl
@@ -161,16 +161,15 @@ end
 
     X = randn(StableRNG(5), 5, 40)
     result = kas(X, [1, 1]; rng = StableRNG(5))
-    
+
     output = sprint((io, x) -> show(io, "text/plain", x), result)
 
-    assignments_preview = 
+    assignments_preview =
         length(result.assignments) > 10 ?
         string("[", join(result.assignments[1:10], ","), ", ...]") :
         string(result.assignments)
-    
+
     expected_string = string(
-        
         " KASResult ($(length(result.counts)) clusters, $(length(result.assignments)) cluster assignments)\n\n",
         " assignments       :   $(assignments_preview)\n\n",
         " Additional Fields: \n\n",

--- a/test/items/algorithms/kss.jl
+++ b/test/items/algorithms/kss.jl
@@ -148,13 +148,12 @@ end
 
     output = sprint((io, x) -> show(io, "text/plain", x), result)
 
-    assignments_preview = 
+    assignments_preview =
         length(result.assignments) > 10 ?
         string("[", join(result.assignments[1:10], ","), ", ...]") :
         string(result.assignments)
 
     expected_string = string(
-        
         " KSSResult ($(length(result.counts)) clusters, $(length(result.assignments)) cluster assignments)\n\n",
         " assignments       :   $(assignments_preview)\n\n",
         " Additional Fields: \n\n",

--- a/test/items/algorithms/kss.jl
+++ b/test/items/algorithms/kss.jl
@@ -139,3 +139,31 @@ end
         @test isempty(filter(l -> l.level == ProgressLogging.ProgressLevel, logger.logs))
     end
 end
+
+@testitem "KSSResult show method" begin
+    using StableRNGs
+
+    X = randn(StableRNG(7), 5, 40)
+    result = kss(X, [1, 1]; rng = StableRNG(7))
+
+    output = sprint((io, x) -> show(io, "text/plain", x), result)
+
+    assignments_preview = 
+        length(result.assignments) > 10 ?
+        string("[", join(result.assignments[1:10], ","), ", ...]") :
+        string(result.assignments)
+
+    expected_string = string(
+        
+        " KSSResult ($(length(result.counts)) clusters, $(length(result.assignments)) cluster assignments)\n\n",
+        " assignments       :   $(assignments_preview)\n\n",
+        " Additional Fields: \n\n",
+        " counts            :   $(result.counts)\n",
+        " iterations        :   $(result.iterations)\n",
+        " converged         :   $(result.converged)\n",
+        " U                 ::  $(typeof(result.U))\n",
+        " totalcost         ::  $(typeof(result.totalcost))\n",
+    )
+
+    @test output == expected_string
+end

--- a/test/items/algorithms/kss.jl
+++ b/test/items/algorithms/kss.jl
@@ -9,7 +9,7 @@
         X = randn(rng, T, D, N)
         d = [2, 2]
         result = kss(X, d)
-        U, c = result.U, result.c
+        U, c = result.U, result.assignments
 
         @test length(U) == length(d)
         @test length(c) == N
@@ -31,7 +31,7 @@ end
         X = randn(rng, T, D, N)
         d = [2, 3, 4]
         result = kss(X, d)
-        U, c = result.U, result.c
+        U, c = result.U, result.assignments
 
         @test length(U) == length(d)
         @test length(c) == N
@@ -56,7 +56,7 @@ end
         X = U1 * randn(rng, d[1], N)
         U2 = SubspaceClustering.randsubspace(rng, T, D, d[2])
         result = kss(X, d; Uinit = [U1, U2])
-        U, c = result.U, result.c
+        U, c = result.U, result.assignments
 
         @test isempty(findall(==(2), c))
     end
@@ -76,7 +76,7 @@ end
             hcat(U1 * randn(rng, d[1], N), U2 * randn(rng, d[2], N)) +
             0.01 * randn(rng, D, 2N)
         result = kss(X, d; Uinit = [U1, U2])
-        U, c = result.U, result.c
+        U, c = result.U, result.assignments
 
         # Checking all the points in X1 are assigned to cluster 1 and all the points in X2 are assigned to cluster 2
         @test all(c[1:N] .== 1)

--- a/test/items/algorithms/tsc.jl
+++ b/test/items/algorithms/tsc.jl
@@ -80,3 +80,29 @@ end
         @test isempty(filter(l -> l.level == ProgressLogging.ProgressLevel, logger.logs))
     end
 end
+
+@testitem "TSCResult show method" begin
+    using StableRNGs
+
+    X = randn(StableRNG(5), 5, 40)
+    result = tsc(X, 3; rng=StableRNG(5))
+
+    output = sprint((io, x) -> show(io, "text/plain", x), result)
+
+    assignments_preview = 
+        length(result.assignments) > 10 ?
+        string("[", join(result.assignments[1:10], ","), ", ...]") :
+        string(result.assignments)
+    
+    expected_string = string(
+
+        " TSCResult ($(size(result.embedding, 1)) clusters, $(length(result.assignments)) cluster assignments)\n\n",
+        " assignments       :   $(assignments_preview)\n\n",
+        " Additional Fields: \n\n",
+        " affinity          :   $(size(result.affinity, 1))x$(size(result.affinity, 2)) matrix\n",
+        " embedding         :   $(size(result.embedding, 1))x$(size(result.embedding, 2)) matrix\n",
+        " kmeans_runs       :   $(length(result.kmeans_runs))\n",
+    )
+
+    @test output == expected_string
+end

--- a/test/items/algorithms/tsc.jl
+++ b/test/items/algorithms/tsc.jl
@@ -85,17 +85,16 @@ end
     using StableRNGs
 
     X = randn(StableRNG(5), 5, 40)
-    result = tsc(X, 3; rng=StableRNG(5))
+    result = tsc(X, 3; rng = StableRNG(5))
 
     output = sprint((io, x) -> show(io, "text/plain", x), result)
 
-    assignments_preview = 
+    assignments_preview =
         length(result.assignments) > 10 ?
         string("[", join(result.assignments[1:10], ","), ", ...]") :
         string(result.assignments)
-    
-    expected_string = string(
 
+    expected_string = string(
         " TSCResult ($(size(result.embedding, 1)) clusters, $(length(result.assignments)) cluster assignments)\n\n",
         " assignments       :   $(assignments_preview)\n\n",
         " Additional Fields: \n\n",


### PR DESCRIPTION
### This PR adds custom show methods for `KSSResult`, `KASResult`, and `TSCResult`

The new display methods focus on the cluster assignments while summarizing additional metadata and intermediate fields. 

Additional changes include:
1. Renamed the output field `c` to `assignments` in `KSSResult` and `KASResult` for consistency with `TSCResult` and for a cleaner API. 
2. Updated the corresponding documentation and examples to reflect that field name change. 

Toward #44 