### PR TITLE
Add paper references to the docstrings

### DIFF
--- a/docs/src/algs/kas.md
+++ b/docs/src/algs/kas.md
@@ -6,6 +6,21 @@
 
     Write up mathematical background here
 
+## References
+
+KAS Implementation follows the formulation introduced in:
+```bibtex
+@article{bradley2000k,
+  title={K-plane clustering},
+  author={Bradley, Paul S and Mangasarian, Olvi L},
+  journal={Journal of Global optimization},
+  volume={16},
+  number={1},
+  pages={23--32},
+  year={2000},
+  publisher={Springer}
+}
+```
 ## Syntax
 
 The following function runs KAS:

--- a/docs/src/algs/kss.md
+++ b/docs/src/algs/kss.md
@@ -6,6 +6,21 @@
 
     Write up mathematical background here
 
+## References
+
+KSS Implementation follows the formulation introduced in:
+```bibtex
+@article{bradley2000k,
+  title={K-plane clustering},
+  author={Bradley, Paul S and Mangasarian, Olvi L},
+  journal={Journal of Global optimization},
+  volume={16},
+  number={1},
+  pages={23--32},
+  year={2000},
+  publisher={Springer}
+}
+```
 ## Syntax
 
 The following function runs KSS:

--- a/docs/src/algs/tsc.md
+++ b/docs/src/algs/tsc.md
@@ -6,6 +6,22 @@
 
     Write up mathematical background here
 
+## References
+
+TSC Implementation follows the formulation introduced in:
+```bibtex
+@article{heckel2015robust,
+  title={Robust subspace clustering via thresholding},
+  author={Heckel, Reinhard and B{\"o}lcskei, Helmut},
+  journal={IEEE transactions on information theory},
+  volume={61},
+  number={11},
+  pages={6320--6342},
+  year={2015},
+  publisher={IEEE}
+}
+```
+
 ## Syntax
 
 The following function runs TSC:


### PR DESCRIPTION
### This PR adds References section in the documentation to cite the papers and methods used to build the algorithms. 

Toward #46 