### PR TITLE
Rework KSS/KAS algorithm result fields

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -62,14 +62,14 @@ hidedecorations!(ax)
 hidespines!(ax)
 
 # Plot estimated subspaces
-for (j, Uj) in enumerate(result.U)
+for (j, Uj) in enumerate(result.bases)
     ablines!(ax, 0, Uj[2,1]/Uj[1,1];
         color = Cycled(j+1), label = "subspace $j")
 end
 
 # Plot data points
 points = map(1:K) do j
-    scatter!(ax, [Point2f(x[i]) for i in 1:N if result.c[i] == j];
+    scatter!(ax, [Point2f(x[i]) for i in 1:N if result.assignments[i] == j];
         markersize = 6, color = Cycled(j+1))
 end
 

--- a/docs/src/quickstart.md
+++ b/docs/src/quickstart.md
@@ -155,14 +155,14 @@ and some metadata about the algorithm run.
 We can extract each of these as follows:
 
 ```@repl
-result.U
-result.c
+result.bases
+result.assignments
 ```
 
 To see how well `kss` clustered the data points,
-we plot these estimated subspaces `results.U`
+we plot these estimated subspaces `results.bases`
 together with the data points
-colored by the estimated cluster assignments `results.c`
+colored by the estimated cluster assignments `results.assignments`
 (the uncolored data points seen by `kss` are shown on the left):
 
 ```@setup
@@ -197,14 +197,14 @@ hidedecorations!(ax)
 hidespines!(ax)
 
 # Plot estimated subspaces
-for (j, Uj) in enumerate(result.U)
+for (j, Uj) in enumerate(result.bases)
     ablines!(ax, 0, Uj[2,1]/Uj[1,1];
         color = Cycled(j+1), label = "subspace $j")
 end
 
 # Plot data points
 points = map(1:K) do j
-    scatter!(ax, [Point2f(x[i]) for i in 1:N if result.c[i] == j];
+    scatter!(ax, [Point2f(x[i]) for i in 1:N if result.assignments[i] == j];
         markersize = 6, color = Cycled(j+1))
 end
 

--- a/src/algorithms/kas.jl
+++ b/src/algorithms/kas.jl
@@ -13,9 +13,9 @@
 The output of [`kas`](@ref).
 
 # Fields
-- `U::TU`: vector of affine space basis matrices `U[1],...,U[K]`
-- `b::Tb`: vector of bias vectors `b[1],...,b[K]`
-- `c::Tc`: vector of cluster assignments `c[1],...,c[N]`
+- `bases::TU`: vector of affine space basis matrices `bases[1],...,bases[K]`
+- `biases::Tb`: vector of bias vectors `biases[1],...,biases[K]`
+- `assignments::Tc`: vector of cluster assignments `assignments[1],...,assignments[N]`
 - `iterations::Int`: number of iterations performed
 - `totalcost::T`: final value of total cost function
 - `counts::Vector{Int}`: vector of cluster sizes `counts[1],...,counts[K]`
@@ -28,9 +28,9 @@ struct KASResult{
     Tc<:AbstractVector{<:Integer},
     T<:Real,
 }
-    U::TU
-    b::Tb
-    c::Tc
+    bases::TU
+    biases::Tb
+    assignments::Tc
     iterations::Int
     totalcost::T
     counts::Vector{Int}
@@ -50,10 +50,18 @@ Cluster the `N` data points in the `D×N` data matrix `X`
 into `K` clusters via the **K**-**a**ffine-**s**paces (KAS) algorithm
 with corresponding affine space dimensions `d[1],...,d[K]`.
 Output is a [`KASResult`](@ref) containing the resulting
-cluster assignments `c[1],...,c[N]`,
-affine space basis matrices `U[1],...,U[K]`,
-bias vectors `b[1],...,b[K]`,
+cluster assignments `assignments[1],...,assignments[N]`,
+affine space basis matrices `bases[1],...,bases[K]`,
+bias vectors `biases[1],...,biases[K]`,
 and metadata about the algorithm run.
+
+For notational convenience, let
+
+- `U = bases`
+- `b = biases`
+- `c = assignments`
+
+where `U[K]` denotes the basis matrix of cluster `K`, `b[K]` denotes the bias vector of cluster `K`, and `c[i]` denotes the cluster assignment of data point `i`.
 
 KAS seeks to cluster data points by their affine space
 by minimizing the following total cost
@@ -70,8 +78,8 @@ and bias vectors `b[1],...,b[K]`.
     (used when reinitializing the affine space for an empty cluster)
 - `init::AbstractVector{<:Tuple{<:AbstractMatrix{TUb},<:AbstractVector{TUb}}}
     = [(randsubspace(rng, float(eltype(X)), size(X, 1), di), zeros(float(eltype(X)), size(X, 1))) for di in d]`:
-    vector of `K` initial pair of affine space basis matrices containing `U[1],...,U[K]`
-    and bias vectors containing `b[1],...,b[K]`
+    vector of `K` initial pair of affine space basis matrices containing `bases[1],...,bases[K]`
+    and bias vectors containing `biases[1],...,biases[K]`
     where `TUb` is a floating point type.
 - `showprogress::Bool = false`: whether to log progress during the algorithm run
 

--- a/src/algorithms/kss.jl
+++ b/src/algorithms/kss.jl
@@ -11,8 +11,8 @@
 The output of [`kss`](@ref).
 
 # Fields
-- `U::TU`: vector of subspace basis matrices `U[1],...,U[K]`
-- `c::Tc`: vector of cluster assignments `c[1],...,c[N]`
+- `bases::TU`: vector of subspace basis matrices `bases[1],...,bases[K]`
+- `assignments::Tc`: vector of cluster assignments `assignments[1],...,assignments[N]`
 - `iterations::Int`: number of iterations performed
 - `totalcost::T`: final value of total cost function
 - `counts::Vector{Int}`: vector of cluster sizes `counts[1],...,counts[K]`
@@ -23,8 +23,8 @@ struct KSSResult{
     Tc<:AbstractVector{<:Integer},
     T<:Real,
 }
-    U::TU
-    c::Tc
+    bases::TU
+    assignments::Tc
     iterations::Int
     totalcost::T
     counts::Vector{Int}
@@ -44,9 +44,16 @@ Cluster the `N` data points in the `D×N` data matrix `X`
 into `K` clusters via the **K**-**s**ub**s**paces (KSS) algorithm
 with corresponding subspace dimensions `d[1],...,d[K]`.
 Output is a [`KSSResult`](@ref) containing the resulting
-cluster assignments `c[1],...,c[N]`,
-subspace basis matrices `U[1],...,U[K]`,
+cluster assignments `assignments[1],...,assignments[N]`,
+subspace basis matrices `bases[1],...,bases[K]`,
 and metadata about the algorithm run.
+
+For notational convenience, let
+
+- `U = bases`
+- `c = assignments`
+
+where `U[K]` denotes the basis matrix of cluster `K` and `c[i]` denotes the cluster assignment of data point `i`.
 
 KSS seeks to cluster data points by their subspace
 by minimizing the following total cost

--- a/test/items/algorithms/kas.jl
+++ b/test/items/algorithms/kas.jl
@@ -9,7 +9,7 @@
         X = randn(rng, T, D, N)
         d = [2, 2]
         result = kas(X, d)
-        U, b, c = result.U, result.b, result.c
+        U, b, c = result.bases, result.biases, result.assignments
 
         @test length(U) == length(d)
         @test length(c) == N
@@ -38,7 +38,7 @@ end
         X = randn(rng, T, D, N)
         d = [2, 3, 4]
         result = kas(X, d)
-        U, b, c = result.U, result.b, result.c
+        U, b, c = result.bases, result.biases, result.assignments
 
         @test length(U) == length(d)
         @test length(c) == N
@@ -72,7 +72,7 @@ end
         U2 = SubspaceClustering.randsubspace(rng, T, D, d[2])
         b2 = zeros(T, D)
         result = kas(X, d; init = [(U1, b1), (U2, b2)])
-        U, b, c = result.U, result.b, result.c
+        U, b, c = result.bases, result.biases, result.assignments
 
         @test isempty(findall(==(2), c))
     end
@@ -93,11 +93,11 @@ end
             hcat(U1 * randn(rng, d[1], N) .+ b1, U2 * randn(rng, d[2], N) .+ b2) .+
             0.01 * randn(rng, D, 2N)
         result = kas(X, d; init = [(U1, b1), (U2, b2)])
-        U, b, c = result.U, result.b, result.c
+        U, b, c = result.bases, result.biases, result.assignments
 
         # Checking all the points in X1 are assigned to cluster 1 and all the points in X2 are assigned to cluster 2
         @test all(c[1:N] .== 1)
-        @test all(c[N+1:end] .== 2)
+        @test all(c[(N+1):end] .== 2)
 
         # Confirming the clusters are not empty
         for k in 1:length(d)

--- a/test/items/algorithms/kss.jl
+++ b/test/items/algorithms/kss.jl
@@ -9,7 +9,7 @@
         X = randn(rng, T, D, N)
         d = [2, 2]
         result = kss(X, d)
-        U, c = result.U, result.c
+        U, c = result.bases, result.assignments
 
         @test length(U) == length(d)
         @test length(c) == N
@@ -31,7 +31,7 @@ end
         X = randn(rng, T, D, N)
         d = [2, 3, 4]
         result = kss(X, d)
-        U, c = result.U, result.c
+        U, c = result.bases, result.assignments
 
         @test length(U) == length(d)
         @test length(c) == N
@@ -56,7 +56,7 @@ end
         X = U1 * randn(rng, d[1], N)
         U2 = SubspaceClustering.randsubspace(rng, T, D, d[2])
         result = kss(X, d; Uinit = [U1, U2])
-        U, c = result.U, result.c
+        U, c = result.bases, result.assignments
 
         @test isempty(findall(==(2), c))
     end
@@ -76,7 +76,7 @@ end
             hcat(U1 * randn(rng, d[1], N), U2 * randn(rng, d[2], N)) +
             0.01 * randn(rng, D, 2N)
         result = kss(X, d; Uinit = [U1, U2])
-        U, c = result.U, result.c
+        U, c = result.bases, result.assignments
 
         # Checking all the points in X1 are assigned to cluster 1 and all the points in X2 are assigned to cluster 2
         @test all(c[1:N] .== 1)


### PR DESCRIPTION
### This PR renames result struct fields in `KSSResult` and `KASResult`

- Renamed the struct fields `U`,`b`, and `c` to `bases`, `biases`, and `assignments`  respectively. 
- Updated documentation and test cases accordingly. 

Toward #58 