### PR TITLE
Add `batch` meta-algorithm for K-Subspaces (KSS) and K-Affine spaces(KAS)

### DIFF
--- a/src/SubspaceClustering.jl
+++ b/src/SubspaceClustering.jl
@@ -10,12 +10,12 @@ using Compat: Compat, @compat
 using LinearAlgebra: Diagonal, I, Symmetric, mul!, normalize, svd!
 using Logging: @info, @warn
 using ProgressLogging: @logprogress, @withprogress
-using Random: AbstractRNG, default_rng, randn!
+using Random: AbstractRNG, default_rng, randn!, MersenneTwister
 using SparseArrays: sparse
 using Statistics: mean
 
 # Exports
-export KASResult, kas, KSSResult, kss, TSCResult, tsc
+export KASResult, kas, KSSResult, kss, TSCResult, tsc, batch
 @compat public randsubspace
 
 # Utility functions/macros
@@ -26,5 +26,8 @@ include("utils/progresslogging.jl")
 include("algorithms/kss.jl")
 include("algorithms/kas.jl")
 include("algorithms/tsc.jl")
+
+# Meta-algorithm
+include("meta/batch.jl")
 
 end

--- a/src/meta/batch.jl
+++ b/src/meta/batch.jl
@@ -1,0 +1,29 @@
+## Batch KSS and KAS Algorithms
+
+"""
+    batch(alg, X, d)
+"""
+function batch(
+    alg::Function,
+    X::AbstractMatrix{<:Number},
+    d::AbstractVector{<:Integer};
+    nruns::Integer = 50,
+    maxiters::Integer = 100,
+    showprogress::Bool = false,
+)
+    # check nruns
+    nruns > 0 || throw(ArgumentError("nruns must be positive. Got `nruns=$nruns`"))
+
+    runs = @withprogressif showprogress map(1:nruns) do idx
+        rng = MersenneTwister(idx)
+        result = alg(X, d; rng=rng, maxiters=maxiters)
+        @logprogressif showprogress idx/nruns
+        return result
+    end
+    
+    # Info on number of converged runs
+    nconverged = count(run -> run.converged, runs)
+    @info "$nconverged/$nruns runs converged"
+
+    return first(sort(runs; by = run -> run.totalcost))
+end

--- a/src/meta/batch.jl
+++ b/src/meta/batch.jl
@@ -41,7 +41,7 @@ function batch(
     runs = @withprogressif showprogress map(1:nruns) do idx
         rng = MersenneTwister(idx)
         result = alg(X, d; rng = rng, maxiters = maxiters)
-        @logprogressif showprogress idx/nruns
+        @logprogressif showprogress idx / nruns
         return result
     end
 

--- a/src/meta/batch.jl
+++ b/src/meta/batch.jl
@@ -1,17 +1,34 @@
 ## Batch KSS and KAS Algorithms
 
 """
-    batch(alg, X, d)
+    batch(alg::Union{typeof(kss), typeof(kas)}, X::AbstractMatrix{<:Number},d::AbstractVector{<:Integer};
+    nruns::Integer = 50,
+    maxiters::Integer = 100,
+    showprogress::Bool = false)
+
+Both K-Subpaces (KSS) and K-Affinespaces (KAS) may get stuck in poor local minima depending on the initialization. Run `kss` and `kas` algorithm multiple times using different random initializations and return the run with the lowest cost.
+
+# Arguments
+- `alg::Union{typeof(kss), typeof(kas)}`: Clustering algorithm to run
+- `X::AbstractMatrix{<:Number}`: Data matrix whose columns are observations
+- `d::AbstractVector{<:Integer}`: Dimensions of the subspaces/affine spaces
+
+# Keyword arguments
+- `nruns::Integer = 50`: Number of independent runs
+- `maxiters::Integer = 100`: Maximum number of iterations per run
+- `showprogress::Bool = false`: whether to log progress for different algorithm runs
+
+See also [`kss`](@ref), [`kas`](@ref).
 """
 function batch(
-    alg::Function,
+    alg::Union{typeof(kss), typeof(kas)},
     X::AbstractMatrix{<:Number},
     d::AbstractVector{<:Integer};
     nruns::Integer = 50,
     maxiters::Integer = 100,
     showprogress::Bool = false,
 )
-    # check nruns
+    # check number of runs
     nruns > 0 || throw(ArgumentError("nruns must be positive. Got `nruns=$nruns`"))
 
     runs = @withprogressif showprogress map(1:nruns) do idx
@@ -25,5 +42,5 @@ function batch(
     nconverged = count(run -> run.converged, runs)
     @info "$nconverged/$nruns runs converged"
 
-    return first(sort(runs; by = run -> run.totalcost))
+    return runs[argmin([run.totalcost for run in runs])]
 end

--- a/src/meta/batch.jl
+++ b/src/meta/batch.jl
@@ -21,7 +21,7 @@ Both K-Subpaces (KSS) and K-Affinespaces (KAS) may get stuck in poor local minim
 See also [`kss`](@ref), [`kas`](@ref).
 """
 function batch(
-    alg::Union{typeof(kss), typeof(kas)},
+    alg::Function,
     X::AbstractMatrix{<:Number},
     d::AbstractVector{<:Integer};
     nruns::Integer = 50,
@@ -29,15 +29,22 @@ function batch(
     showprogress::Bool = false,
 )
     # check number of runs
-    nruns > 0 || throw(ArgumentError("nruns must be positive. Got `nruns=$nruns`"))
+    nruns > 0 || throw(ArgumentError("nruns must be positive. Got `nruns = $nruns`"))
+
+    # Algorithm Check
+    alg in (kss, kas) || throw(
+        ArgumentError(
+            "`batch` currently supports only `kss` and `kas`. Got `alg: $(nameof(alg))`",
+        ),
+    )
 
     runs = @withprogressif showprogress map(1:nruns) do idx
         rng = MersenneTwister(idx)
-        result = alg(X, d; rng=rng, maxiters=maxiters)
+        result = alg(X, d; rng = rng, maxiters = maxiters)
         @logprogressif showprogress idx/nruns
         return result
     end
-    
+
     # Info on number of converged runs
     nconverged = count(run -> run.converged, runs)
     @info "$nconverged/$nruns runs converged"

--- a/test/items/meta/batch.jl
+++ b/test/items/meta/batch.jl
@@ -7,7 +7,7 @@
     U1 = qr(randn(rng, 5, 2)).Q[:, 1:2]
     U2 = qr(randn(rng, 5, 2)).Q[:, 1:2]
 
-    X = [U1*randn(rng, 2, 20) U2*randn(rng, 2, 20)]
+    X = [U1 * randn(rng, 2, 20) U2 * randn(rng, 2, 20)]
     d = [1, 2]
 
     @testset "invalid nruns" begin
@@ -35,7 +35,7 @@ end
     U1 = qr(randn(rng, D, N)).Q[:, 1:3]
     U2 = qr(randn(rng, D, N)).Q[:, 1:3]
 
-    X = [U1*randn(rng, 3, N) U2*randn(rng, 3, N)]
+    X = [U1 * randn(rng, 3, N) U2 * randn(rng, 3, N)]
 
     result = batch(kss, X, [1, 2]; nruns = 5)
     U = result.U
@@ -58,7 +58,7 @@ end
     U1 = qr(randn(rng, D, N)).Q[:, 1:3]
     U2 = qr(randn(rng, D, N)).Q[:, 1:3]
 
-    X = [U1*randn(rng, 3, N) U2*randn(rng, 3, N)]
+    X = [U1 * randn(rng, 3, N) U2 * randn(rng, 3, N)]
 
     result = batch(kas, X, [1, 2]; nruns = 5)
     U, b = result.U, result.b

--- a/test/items/meta/batch.jl
+++ b/test/items/meta/batch.jl
@@ -1,0 +1,76 @@
+
+@testitem "Argument Validation" begin
+    using LinearAlgebra, StableRNGs
+
+    rng = StableRNG(1)
+
+    U1 = qr(randn(rng, 5, 2)).Q[:, 1:2]
+    U2 = qr(randn(rng, 5, 2)).Q[:, 1:2]
+
+    X = [U1*randn(rng, 2, 20) U2*randn(rng, 2, 20)]
+    d = [1, 2]
+
+    @testset "invalid nruns" begin
+        @test_throws ArgumentError batch(kss, X, d; nruns = 0)
+        @test_throws ArgumentError batch(kas, X, d; nruns = -1)
+    end
+
+    @testset "invalid algorithm" begin
+        @test_throws ArgumentError batch(tsc, X, d; nruns = 5)
+    end
+
+    @testset "invalid dimensions" begin
+        @test_throws MethodError batch(kss, X, 2)
+        @test_throws MethodError batch(kas, X, 3)
+    end
+end
+
+@testitem "batch KSS Results" begin
+    using LinearAlgebra, StableRNGs
+
+    rng = StableRNG(2)
+
+    D, N = 10, 50
+
+    U1 = qr(randn(rng, D, N)).Q[:, 1:3]
+    U2 = qr(randn(rng, D, N)).Q[:, 1:3]
+
+    X = [U1*randn(rng, 3, N) U2*randn(rng, 3, N)]
+
+    result = batch(kss, X, [1, 2]; nruns = 5)
+    U = result.U
+
+    @test result isa KSSResult
+    @test length(result.c) == size(X, 2)
+
+    for subspace in U
+        @test isapprox(subspace' * subspace, I, atol = 1e-10)
+    end
+end
+
+@testitem "batch KAS Results" begin
+    using LinearAlgebra, StableRNGs
+
+    rng = StableRNG(3)
+
+    D, N = 10, 50
+
+    U1 = qr(randn(rng, D, N)).Q[:, 1:3]
+    U2 = qr(randn(rng, D, N)).Q[:, 1:3]
+
+    X = [U1*randn(rng, 3, N) U2*randn(rng, 3, N)]
+
+    result = batch(kas, X, [1, 2]; nruns = 5)
+    U, b = result.U, result.b
+
+    @test result isa KASResult
+    @test length(result.c) == size(X, 2)
+
+    for subspace in U
+        @test isapprox(subspace' * subspace, I, atol = 1e-10)
+    end
+    for bias in b
+        @test length(bias) == D
+        @test all(!isnan, bias)
+    end
+end


### PR DESCRIPTION
### This PR introduces a new function `batch` that runs `kss` or `kas` multiple times with different random initializations and returns the result with the lowest total cost. 

- Added a new folder `meta` that houses `batch` function for `kss and kas`. 
- Included docstring for the new function along with a few test cases. 

Toward #29 