### PR TITLE
Add verbose flag to KSS, KAS, and TSC

### DIFF
--- a/src/algorithms/kas.jl
+++ b/src/algorithms/kas.jl
@@ -74,6 +74,7 @@ and bias vectors `b[1],...,b[K]`.
     and bias vectors containing `b[1],...,b[K]`
     where `TUb` is a floating point type.
 - `showprogress::Bool = false`: whether to log progress during the algorithm run
+- `verbose::Bool = false`: whether to print informational log messages
 
 See also [`KASResult`](@ref).
 """
@@ -89,6 +90,7 @@ function kas(
         ) for di in d
     ],
     showprogress::Bool = false,
+    verbose::Bool = false,
 ) where {TUb<:Union{AbstractFloat,Complex{<:AbstractFloat}}}
     # Unpack the initial affine space basis matrices and bias vectors
     Uinit = first.(init)
@@ -162,7 +164,8 @@ function kas(
 
         # Check for convergence
         if cprev == c
-            @info "Converged after $iterations $(iterations == 1 ? "iteration" : "iterations")."
+            verbose &&
+                @info "Converged after $iterations $(iterations == 1 ? "iteration" : "iterations")."
             converged = true
         end
         copyto!(cprev, c)

--- a/src/algorithms/kss.jl
+++ b/src/algorithms/kss.jl
@@ -66,6 +66,7 @@ and subspace basis matrices `U[1],...,U[K]`.
     (each `Uinit[k]` should be `D×d[k]` and have eltype `T`
     where `T` is a floating point type)
 - `showprogress::Bool = false`: whether to log progress during the algorithm run
+- `verbose::Bool = false`: whether to print informational log messages
 
 See also [`KSSResult`](@ref).
 """
@@ -78,6 +79,7 @@ function kss(
         <:AbstractMatrix{<:Union{AbstractFloat,Complex{<:AbstractFloat}}},
     } = [randsubspace(rng, float(eltype(X)), size(X, 1), di) for di in d],
     showprogress::Bool = false,
+    verbose::Bool = false,
 )
     # Require one-based indexing
     Base.require_one_based_indexing(X, d, Uinit)
@@ -137,7 +139,8 @@ function kss(
 
         # Check for convergence
         if cprev == c
-            @info "Converged after $iterations $(iterations == 1 ? "iteration" : "iterations")."
+            verbose &&
+                @info "Converged after $iterations $(iterations == 1 ? "iteration" : "iterations")."
             converged = true
         end
         copyto!(cprev, c)

--- a/src/algorithms/tsc.jl
+++ b/src/algorithms/tsc.jl
@@ -59,6 +59,7 @@ via normalized spectral clustering of the graph.
 - `kmeans_nruns::Integer = 10`: number of K-means runs to perform
 - `kmeans_opts = (;)`: additional options for `kmeans`
 - `showprogress::Bool = false`: whether to log progress during the algorithm run
+- `verbose::Bool = false`: whether to print informational log messages
 
 See also [`TSCResult`](@ref), [`tsc_affinity`](@ref), [`tsc_embedding`](@ref).
 """
@@ -71,6 +72,7 @@ function tsc(
     kmeans_nruns::Integer = 10,
     kmeans_opts = (;),
     showprogress::Bool = false,
+    verbose::Bool = false,
 )
     # Validate arguments
     Base.require_one_based_indexing(X)
@@ -91,15 +93,15 @@ function tsc(
     )
 
     # Form affinity matrix
-    @info "Forming affinity matrix"
+    verbose && @info "Forming affinity matrix"
     A = tsc_affinity(X; max_nz, max_chunksize, showprogress)
 
     # Compute embedding
-    @info "Computing embedding"
+    verbose && @info "Computing embedding"
     E = tsc_embedding(A, K)
 
     # Compute cluster assignments via batched K-means
-    @info "Running batched K-means with $kmeans_nruns runs"
+    verbose && @info "Running batched K-means with $kmeans_nruns runs"
     results = @withprogressif showprogress map(1:kmeans_nruns) do run
         result = kmeans(E, K; rng, kmeans_opts...)
         @logprogressif showprogress run / kmeans_nruns

--- a/test/items/algorithms/kas.jl
+++ b/test/items/algorithms/kas.jl
@@ -97,7 +97,7 @@ end
 
         # Checking all the points in X1 are assigned to cluster 1 and all the points in X2 are assigned to cluster 2
         @test all(c[1:N] .== 1)
-        @test all(c[N+1:end] .== 2)
+        @test all(c[(N+1):end] .== 2)
 
         # Confirming the clusters are not empty
         for k in 1:length(d)
@@ -153,5 +153,36 @@ end
             return kas(X, d; showprogress = false, rng = StableRNG(0), maxiters = 10)
         end
         @test isempty(filter(l -> l.level == ProgressLogging.ProgressLevel, logger.logs))
+    end
+end
+
+@testitem "verbose flag" begin
+    using LinearAlgebra, Logging, StableRNGs, Test
+
+    # Generate Noiseless data from three affine spaces.
+    rng = StableRNG(6)
+    d = fill(2, 3)
+
+    init = [(SubspaceClustering.randsubspace(rng, 100, dk), randn(rng, 100)) for dk in d]
+    X = reduce(hcat, [Uk * randn(rng, dk, 10) .+ bk for ((Uk, bk), dk) in zip(init, d)])
+
+    @testset "verbose=true" begin
+        logger = TestLogger(; min_level = Logging.Info)
+        with_logger(logger) do
+            return kas(X, d; init = init, verbose = true, rng = StableRNG(6))
+        end
+
+        info_logs = filter(l -> l.level == Logging.Info, logger.logs)
+        logged_messages = [string(l.message) for l in info_logs]
+        @test logged_messages == ["Converged after 1 iteration."]
+    end
+
+    @testset "verbose=false" begin
+        logger = TestLogger(; min_level = Logging.Info)
+        with_logger(logger) do
+            return kas(X, d; init = init, verbose = false, rng = StableRNG(6))
+        end
+
+        @test isempty(filter(l -> l.level == Logging.Info, logger.logs))
     end
 end

--- a/test/items/algorithms/kss.jl
+++ b/test/items/algorithms/kss.jl
@@ -139,3 +139,33 @@ end
         @test isempty(filter(l -> l.level == ProgressLogging.ProgressLevel, logger.logs))
     end
 end
+
+@testitem "verbose flag" begin
+    using LinearAlgebra, Logging, StableRNGs, Test
+
+    # Generate Noiseless data from three subspaces
+    rng = StableRNG(6)
+    d = fill(2, 3)
+    Uinit = [SubspaceClustering.randsubspace(rng, 100, dk) for dk in d]
+    X = reduce(hcat, [Uk*randn(rng, dk, 10) for (Uk, dk) in zip(Uinit, d)])
+
+    @testset "verbose=true" begin
+        logger = TestLogger(; min_level = Logging.Info)
+        with_logger(logger) do
+            return kss(X, d; Uinit = Uinit, verbose = true, rng = StableRNG(6))
+        end
+
+        info_logs = filter(l -> l.level == Logging.Info, logger.logs)
+        logged_messages = [string(l.message) for l in info_logs]
+        @test logged_messages == ["Converged after 1 iteration."]
+    end
+
+    @testset "verbose=false" begin
+        logger = TestLogger(; min_level = Logging.Info)
+        with_logger(logger) do
+            return kss(X, d; Uinit = Uinit, verbose = false, rng = StableRNG(6))
+        end
+
+        @test isempty(filter(l -> l.level == Logging.Info, logger.logs))
+    end
+end

--- a/test/items/algorithms/kss.jl
+++ b/test/items/algorithms/kss.jl
@@ -147,7 +147,7 @@ end
     rng = StableRNG(6)
     d = fill(2, 3)
     Uinit = [SubspaceClustering.randsubspace(rng, 100, dk) for dk in d]
-    X = reduce(hcat, [Uk*randn(rng, dk, 10) for (Uk, dk) in zip(Uinit, d)])
+    X = reduce(hcat, [Uk * randn(rng, dk, 10) for (Uk, dk) in zip(Uinit, d)])
 
     @testset "verbose=true" begin
         logger = TestLogger(; min_level = Logging.Info)

--- a/test/items/algorithms/tsc.jl
+++ b/test/items/algorithms/tsc.jl
@@ -80,3 +80,51 @@ end
         @test isempty(filter(l -> l.level == ProgressLogging.ProgressLevel, logger.logs))
     end
 end
+
+@testitem "verbose flag" begin
+    using LinearAlgebra, Logging, StableRNGs, Test
+
+    # Generate data
+    rng = StableRNG(4)
+    kmeans_nruns = 5
+    X = reduce(hcat, [svd(randn(rng, 100, 2)).U * randn(rng, 2, 10) for _ in 1:3])
+
+    @testset "verbose=true" begin
+        logger = TestLogger(; min_level = Logging.Info)
+        with_logger(logger) do
+            return tsc(
+                X,
+                3;
+                verbose = true,
+                rng = StableRNG(4),
+                kmeans_nruns = kmeans_nruns,
+                max_chunksize = 3,
+            )
+        end
+
+        info_logs = filter(l -> l.level == Logging.Info, logger.logs)
+        logged_messages = [string(l.message) for l in info_logs]
+
+        @test logged_messages == [
+            "Forming affinity matrix",
+            "Computing embedding",
+            "Running batched K-means with $kmeans_nruns runs",
+        ]
+    end
+
+    @testset "verbose=false" begin
+        logger = TestLogger(; min_level = Logging.Info)
+        with_logger(logger) do
+            return tsc(
+                X,
+                3;
+                verbose = false,
+                rng = StableRNG(4),
+                kmeans_nruns = kmeans_nruns,
+                max_chunksize = 3,
+            )
+        end
+
+        @test isempty(filter(l -> l.level == Logging.Info, logger.logs))
+    end
+end


### PR DESCRIPTION
### This PR adds a verbose flag to the clustering algorithms

**Changes:**

- Added a boolean keyword argument, `verbose::Bool=false` to `kss`, `kas`, and `tsc` to control information logging. 
- Added test cases for all three algorithms to verify the expected logging behavior. 

Toward #62 