### PR TITLE
Add meaningful names to progress loggers

### DIFF
--- a/src/algorithms/kas.jl
+++ b/src/algorithms/kas.jl
@@ -143,7 +143,7 @@ function kas(
     iterations, converged = 0, false
     log_every = max(1, maxiters ÷ 100)
     @withprogressif showprogress name = "Running KAS" while iterations < maxiters &&
-                                                               !converged
+                                                            !converged
         iterations += 1
 
         # Update affine space basis matrices and bias vectors

--- a/src/algorithms/kas.jl
+++ b/src/algorithms/kas.jl
@@ -142,7 +142,8 @@ function kas(
     cprev = copy(c)
     iterations, converged = 0, false
     log_every = max(1, maxiters ÷ 100)
-    @withprogressif showprogress while iterations < maxiters && !converged
+    @withprogressif showprogress name = "Running KAS" while iterations < maxiters &&
+                                                               !converged
         iterations += 1
 
         # Update affine space basis matrices and bias vectors

--- a/src/algorithms/kss.jl
+++ b/src/algorithms/kss.jl
@@ -118,7 +118,8 @@ function kss(
     cprev = copy(c)
     iterations, converged = 0, false
     log_every = max(1, maxiters ÷ 100)
-    @withprogressif showprogress while iterations < maxiters && !converged
+    @withprogressif showprogress name = "Running KSS" while iterations < maxiters &&
+                                                               !converged
         iterations += 1
 
         # Update subspaces

--- a/src/algorithms/kss.jl
+++ b/src/algorithms/kss.jl
@@ -119,7 +119,7 @@ function kss(
     iterations, converged = 0, false
     log_every = max(1, maxiters ÷ 100)
     @withprogressif showprogress name = "Running KSS" while iterations < maxiters &&
-                                                               !converged
+                                                            !converged
         iterations += 1
 
         # Update subspaces

--- a/src/algorithms/tsc.jl
+++ b/src/algorithms/tsc.jl
@@ -100,7 +100,7 @@ function tsc(
 
     # Compute cluster assignments via batched K-means
     @info "Running batched K-means with $kmeans_nruns runs"
-    results = @withprogressif showprogress map(1:kmeans_nruns) do run
+    results = @withprogressif showprogress name = "Running k-means" map(1:kmeans_nruns) do run
         result = kmeans(E, K; rng, kmeans_opts...)
         @logprogressif showprogress run / kmeans_nruns
         return result
@@ -141,7 +141,7 @@ function tsc_affinity(
     C_buf = similar(Y, N, chunksize)    # buffer for pairwise absolute cosine similarities
     s_buf = Vector{Int}(undef, N)       # buffer for sorting
     chunks = Iterators.partition(1:N, chunksize)
-    Z_nzs = @withprogressif showprogress mapreduce(
+    Z_nzs = @withprogressif showprogress name = "Computing affinity matrix" mapreduce(
         vcat,
         enumerate(chunks),
     ) do (chunk_idx, chunk)

--- a/src/algorithms/tsc.jl
+++ b/src/algorithms/tsc.jl
@@ -100,7 +100,9 @@ function tsc(
 
     # Compute cluster assignments via batched K-means
     @info "Running batched K-means with $kmeans_nruns runs"
-    results = @withprogressif showprogress name = "Running k-means" map(1:kmeans_nruns) do run
+    results = @withprogressif showprogress name = "Running k-means" map(
+        1:kmeans_nruns,
+    ) do run
         result = kmeans(E, K; rng, kmeans_opts...)
         @logprogressif showprogress run / kmeans_nruns
         return result


### PR DESCRIPTION
### This PR adds descriptive names to all `@withprogressif` calls in the package.

**Changes:**

- `@withprogressif` – Added descriptive names to the KSS and KAS iteration progress loggers, the TSC affinity matrix computation progress logger, and the batched K-means progress logger.
- Improves readability of the progress output. 

Toward #64 